### PR TITLE
Fix type Session and changed default interval for update Session

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import { ChannelCredentials } from 'grpc';
 
 interface GenericConfig {
-  pollInterval: number;
+  pollInterval?: number;
 }
 
 export interface OAuthCredentialsConfig extends GenericConfig {

--- a/index.js
+++ b/index.js
@@ -39,8 +39,9 @@ function newChannelCredentials(tokenCreator) {
     })
   );
 }
+const ONE_HOUR = 1000 * 60 * 60;
 const defaultConfig = {
-  pollInterval: 1000,
+  pollInterval: ONE_HOUR,
   metadataToken: false
 };
 class Session {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [https://yandex.ru/legal/cla/?lang=ru].

Hello. Thanks you for the sdk.

I changed type for constructor because if we have default config, we don't need require  `pollInterval`.

In [docs](https://cloud.yandex.ru/docs/iam/operations/iam-token/create-for-sa) advise use interval for update in one hour. 