### PR TITLE
fix(retry): copy retry middleware to SDK and fix it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "^1.6.12",
+        "abort-controller-x": "^0.4.1",
         "axios": "^0.24.0",
         "jsonwebtoken": "^9.0.0",
         "lodash": "^4.17.21",
@@ -18,7 +19,7 @@
         "luxon": "^2.2.0",
         "nice-grpc": "^1.0.6",
         "nice-grpc-client-middleware-deadline": "^1.0.6",
-        "nice-grpc-client-middleware-retry": "^1.1.2",
+        "node-abort-controller": "^3.1.1",
         "protobufjs": "^6.11.3",
         "utility-types": "^3.10.0"
       },
@@ -2302,12 +2303,9 @@
       "dev": true
     },
     "node_modules/abort-controller-x": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.2.6.tgz",
-      "integrity": "sha512-U8MmmcfIzl7qnzoog1woxKX/eYkQin3WR7k/S2dtpGLlSlsndXnvOYQEq8y1VnHC3+ofNFAT0GRgHq1lBbXlDQ==",
-      "dependencies": {
-        "node-abort-controller": "^1.2.1 || ^2.0.0"
-      }
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.4.1.tgz",
+      "integrity": "sha512-lJ2ssrl3FoTK3cX/g15lRCkXFWKiwRTRtBjfwounO2EM/Q65rI/MEZsfsch1juWU2pH2aLSaq0HGowlDP/imrw=="
     },
     "node_modules/acorn": {
       "version": "8.6.0",
@@ -7353,21 +7351,6 @@
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-2.0.0.tgz",
       "integrity": "sha512-L8RfEgjBTHAISTuagw51PprVAqNZoG6KSB6LQ6H1bskMVkFs5E71IyjauLBv3XbuomJlguWF/VnRHdJ1gqiAqA=="
     },
-    "node_modules/nice-grpc-client-middleware-retry": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/nice-grpc-client-middleware-retry/-/nice-grpc-client-middleware-retry-1.1.2.tgz",
-      "integrity": "sha512-7RWHpQxQ6Dq++TTaP/S/GFd4MuSd1jjeQr8q41oQ6phyPRTZmNx8gdbVQg2Q70iATFjJ9eQfj4/QysfeQ3LURQ==",
-      "dependencies": {
-        "abort-controller-x": "^0.2.6",
-        "nice-grpc-common": "^1.1.0",
-        "node-abort-controller": "^2.0.0"
-      }
-    },
-    "node_modules/nice-grpc-client-middleware-retry/node_modules/node-abort-controller": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-2.0.0.tgz",
-      "integrity": "sha512-L8RfEgjBTHAISTuagw51PprVAqNZoG6KSB6LQ6H1bskMVkFs5E71IyjauLBv3XbuomJlguWF/VnRHdJ1gqiAqA=="
-    },
     "node_modules/nice-grpc-common": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nice-grpc-common/-/nice-grpc-common-1.1.0.tgz",
@@ -7382,10 +7365,23 @@
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-2.0.0.tgz",
       "integrity": "sha512-L8RfEgjBTHAISTuagw51PprVAqNZoG6KSB6LQ6H1bskMVkFs5E71IyjauLBv3XbuomJlguWF/VnRHdJ1gqiAqA=="
     },
-    "node_modules/node-abort-controller": {
+    "node_modules/nice-grpc/node_modules/abort-controller-x": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.2.7.tgz",
+      "integrity": "sha512-hq/lt8yODKrwuZa69GhSTl2l2kcrus2khZ7OjD6Bmqmx6tbW6dnV8cVGnkkdLCWnjXpgSx8zjQo+HUc9mvoQ/w==",
+      "dependencies": {
+        "node-abort-controller": "^1.2.1 || ^2.0.0"
+      }
+    },
+    "node_modules/nice-grpc/node_modules/node-abort-controller": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-1.2.1.tgz",
       "integrity": "sha512-79PYeJuj6S9+yOHirR0JBLFOgjB6sQCir10uN6xRx25iD+ZD4ULqgRn3MwWBRaQGB0vEgReJzWwJo42T1R6YbQ=="
+    },
+    "node_modules/node-abort-controller": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
     },
     "node_modules/node-emoji": {
       "version": "1.11.0",
@@ -14053,12 +14049,9 @@
       "dev": true
     },
     "abort-controller-x": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.2.6.tgz",
-      "integrity": "sha512-U8MmmcfIzl7qnzoog1woxKX/eYkQin3WR7k/S2dtpGLlSlsndXnvOYQEq8y1VnHC3+ofNFAT0GRgHq1lBbXlDQ==",
-      "requires": {
-        "node-abort-controller": "^1.2.1 || ^2.0.0"
-      }
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.4.1.tgz",
+      "integrity": "sha512-lJ2ssrl3FoTK3cX/g15lRCkXFWKiwRTRtBjfwounO2EM/Q65rI/MEZsfsch1juWU2pH2aLSaq0HGowlDP/imrw=="
     },
     "acorn": {
       "version": "8.6.0",
@@ -17917,6 +17910,21 @@
         "abort-controller-x": "^0.2.4",
         "nice-grpc-common": "^1.0.4",
         "node-abort-controller": "^1.2.1"
+      },
+      "dependencies": {
+        "abort-controller-x": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.2.7.tgz",
+          "integrity": "sha512-hq/lt8yODKrwuZa69GhSTl2l2kcrus2khZ7OjD6Bmqmx6tbW6dnV8cVGnkkdLCWnjXpgSx8zjQo+HUc9mvoQ/w==",
+          "requires": {
+            "node-abort-controller": "^1.2.1 || ^2.0.0"
+          }
+        },
+        "node-abort-controller": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-1.2.1.tgz",
+          "integrity": "sha512-79PYeJuj6S9+yOHirR0JBLFOgjB6sQCir10uN6xRx25iD+ZD4ULqgRn3MwWBRaQGB0vEgReJzWwJo42T1R6YbQ=="
+        }
       }
     },
     "nice-grpc-client-middleware-deadline": {
@@ -17925,23 +17933,6 @@
       "integrity": "sha512-AokugSveg+2IPohuLbGR5OITgh3W4yZvAmLhuqistjwSRLchzQI4CwQEL1Tj4R0wscreSFoiHkXyG4qtKygOug==",
       "requires": {
         "nice-grpc-common": "^1.0.4",
-        "node-abort-controller": "^2.0.0"
-      },
-      "dependencies": {
-        "node-abort-controller": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-2.0.0.tgz",
-          "integrity": "sha512-L8RfEgjBTHAISTuagw51PprVAqNZoG6KSB6LQ6H1bskMVkFs5E71IyjauLBv3XbuomJlguWF/VnRHdJ1gqiAqA=="
-        }
-      }
-    },
-    "nice-grpc-client-middleware-retry": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/nice-grpc-client-middleware-retry/-/nice-grpc-client-middleware-retry-1.1.2.tgz",
-      "integrity": "sha512-7RWHpQxQ6Dq++TTaP/S/GFd4MuSd1jjeQr8q41oQ6phyPRTZmNx8gdbVQg2Q70iATFjJ9eQfj4/QysfeQ3LURQ==",
-      "requires": {
-        "abort-controller-x": "^0.2.6",
-        "nice-grpc-common": "^1.1.0",
         "node-abort-controller": "^2.0.0"
       },
       "dependencies": {
@@ -17969,9 +17960,9 @@
       }
     },
     "node-abort-controller": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-1.2.1.tgz",
-      "integrity": "sha512-79PYeJuj6S9+yOHirR0JBLFOgjB6sQCir10uN6xRx25iD+ZD4ULqgRn3MwWBRaQGB0vEgReJzWwJo42T1R6YbQ=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
     },
     "node-emoji": {
       "version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "luxon": "^2.2.0",
     "nice-grpc": "^1.0.6",
     "nice-grpc-client-middleware-deadline": "^1.0.6",
-    "nice-grpc-client-middleware-retry": "^1.1.2",
+    "abort-controller-x": "^0.4.1",
+    "node-abort-controller": "^3.1.1",
     "protobufjs": "^6.11.3",
     "utility-types": "^3.10.0"
   },

--- a/src/middleware/retry.ts
+++ b/src/middleware/retry.ts
@@ -1,0 +1,129 @@
+import {
+    delay,
+    rethrowAbortError,
+} from 'abort-controller-x';
+import {
+    ClientError,
+    ClientMiddleware,
+    Status,
+} from 'nice-grpc';
+import { AbortController } from 'node-abort-controller';
+
+/**
+ * These options are added to `CallOptions` by
+ * `nice-grpc-client-middleware-retry`.
+ */
+export type RetryOptions = {
+    /**
+     * Boolean indicating whether retries are enabled.
+     *
+     * If the method is marked as idempotent in Protobuf, i.e. has
+     *
+     *     option idempotency_level = IDEMPOTENT;
+     *
+     * then the default is `true`. Otherwise, the default is `false`.
+     *
+     * Method options currently work only when compiling with `ts-proto`.
+     */
+    retry?: boolean;
+    /**
+     * Base delay between retry attempts in milliseconds.
+     *
+     * Defaults to 1000.
+     *
+     * Example: if `retryBaseDelayMs` is 100, then retries will be attempted in
+     * 100ms, 200ms, 400ms etc. (not counting jitter).
+     */
+    retryBaseDelayMs?: number;
+    /**
+     * Maximum delay between attempts in milliseconds.
+     *
+     * Defaults to 15 seconds.
+     *
+     * Example: if `retryBaseDelayMs` is 1000 and `retryMaxDelayMs` is 3000, then
+     * retries will be attempted in 1000ms, 2000ms, 3000ms, 3000ms etc (not
+     * counting jitter).
+     */
+    retryMaxDelayMs?: number;
+    /**
+     * Maximum for the total number of attempts. `Infinity` is supported.
+     *
+     * Defaults to 1, i.e. a single retry will be attempted.
+     */
+    retryMaxAttempts?: number;
+    /**
+     * Array of retryable status codes.
+     *
+     * Default is `[UNKNOWN, RESOURCE_EXHAUSTED, INTERNAL, UNAVAILABLE]`.
+     */
+    retryableStatuses?: Status[];
+    /**
+     * Called after receiving error with retryable status code before setting
+     * backoff delay timer.
+     *
+     * If the error code is not retryable, or the maximum attempts exceeded, this
+     * function will not be called and the error will be thrown from the client
+     * method.
+     */
+    onRetryableError?(error: ClientError, attempt: number, delayMs: number): void;
+};
+
+const defaultRetryableStatuses: Status[] = [
+    Status.UNKNOWN,
+    Status.RESOURCE_EXHAUSTED,
+    Status.INTERNAL,
+    Status.UNAVAILABLE,
+];
+
+/**
+ * Client middleware that adds automatic retries to unary calls.
+ */
+export const retryMiddleware: ClientMiddleware<RetryOptions> = async function* retryMiddleware(call, options) {
+    const { idempotencyLevel } = call.method.options ?? {};
+    const isIdempotent = idempotencyLevel === 'IDEMPOTENT'
+        || idempotencyLevel === 'NO_SIDE_EFFECTS';
+
+    const {
+        retry = isIdempotent,
+        retryBaseDelayMs = 1000,
+        retryMaxDelayMs = 15_000,
+        retryMaxAttempts = 1,
+        onRetryableError,
+        retryableStatuses = defaultRetryableStatuses,
+        ...restOptions
+    } = options;
+
+    if (call.requestStream || call.responseStream || !retry) {
+        return yield* call.next(call.request, restOptions);
+    }
+
+    const signal = options.signal ?? new AbortController().signal;
+
+    for (let attempt = 0; ; attempt++) {
+        try {
+            return yield* call.next(call.request, restOptions);
+        } catch (error: unknown) {
+            rethrowAbortError(error);
+
+            if (
+                attempt >= retryMaxAttempts
+                || !(error instanceof ClientError)
+                || !retryableStatuses.includes(error.code)
+            ) {
+                throw error;
+            }
+
+            // https://aws.amazon.com/ru/blogs/architecture/exponential-backoff-and-jitter/
+            const backoff = Math.min(
+                retryMaxDelayMs,
+                2 ** attempt * retryBaseDelayMs,
+            );
+            const delayMs = Math.round((backoff * (1 + Math.random())) / 2);
+
+            onRetryableError?.(error, attempt, delayMs);
+
+            // eslint-disable-next-line no-await-in-loop
+            await delay(signal, delayMs);
+        }
+    }
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,8 @@ import {
 } from '@grpc/grpc-js';
 import { RawClient } from 'nice-grpc';
 import { DeadlineOptions } from 'nice-grpc-client-middleware-deadline';
-import { RetryOptions } from 'nice-grpc-client-middleware-retry';
 import { NormalizedServiceDefinition } from 'nice-grpc/lib/service-definitions';
+import { RetryOptions } from './middleware/retry';
 
 export interface TokenService {
     getToken: () => Promise<string>;

--- a/src/utils/client-factory.ts
+++ b/src/utils/client-factory.ts
@@ -1,6 +1,6 @@
 import { createClientFactory } from 'nice-grpc';
 import { deadlineMiddleware } from 'nice-grpc-client-middleware-deadline';
-import { retryMiddleware } from 'nice-grpc-client-middleware-retry';
+import { retryMiddleware } from '../middleware/retry';
 
 export const clientFactory = createClientFactory()
     .use(retryMiddleware)


### PR DESCRIPTION
As retry middleware from [nice-grpc-client-middleware-retry](https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc-client-middleware-retry) package highly relates to the way stubs are generated, I had to copy it and fix the destructuring issue.

The original middleware [presumes](https://github.com/deeplay-io/nice-grpc/tree/master/packages/nice-grpc#using-ts-proto) that ts-proto is used with `--ts_proto_opt=outputServices=generic-definitions` option, that add `options` [property object](https://github.com/stephenh/ts-proto/blob/be5465fa2ccf2cd455c563ea3a18a14e1efc79fa/src/generate-generic-service-definition.ts#L74) to the method, so it could be later successfully destructured.

closes #113 