### PR TITLE
feat: make possible to provide additional auth headers needed for AI services

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export interface ChannelSslOptions {
 export interface GenericCredentialsConfig {
     pollInterval?: number;
     ssl?: ChannelSslOptions
+    headers?: Record<string, string>;
 }
 
 export interface OAuthCredentialsConfig extends GenericCredentialsConfig {


### PR DESCRIPTION
There are some services (SpeechKit, LLM, Vision), that require additional `x-folder-id` header, when are used with IAM token issued for user or federated user subject type. https://cloud.yandex.com/en-ru/docs/yandexgpt/api-ref/authentication

Closes #148 