### PR TITLE
YCIAM-9515 oauth token deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,29 +14,10 @@ Need to automate your infrastructure or use services provided by Yandex.Cloud? W
 ## Getting started
 
 There are three options for authorization your requests:
-- [OAuth Token](https://cloud.yandex.com/en-ru/docs/iam/concepts/authorization/oauth-token)
 - [IAM token](https://cloud.yandex.com/en-ru/docs/iam/operations/iam-token/create)
 - [Metadata Service](https://cloud.yandex.com/en-ru/docs/compute/concepts/vm-metadata) (if you're executing code inside VMs or Functions
 running in Yandex.Cloud)
 
-### OAuth Token
-
-```typescript
-import { Session, cloudApi, serviceClients } from '@yandex-cloud/nodejs-sdk';
-
-const { resourcemanager: { cloud_service: { ListCloudsRequest } } } = cloudApi;
-
-// Initialize SDK with your token
-const session = new Session({ oauthToken: 'YOUR_TOKEN' });
-
-// Create service client
-const cloudService = session.client(serviceClients.CloudServiceClient);
-
-// Issue request (returns Promise)
-const response = await cloudService.list(ListCloudsRequest.fromPartial({
-    pageSize: 100,
-}));
-```
 
 ### Metadata Service
 
@@ -84,7 +65,7 @@ To run example scripts, you should execute the following commands:
 ```bash
 cd examples
 npm i
-YC_OAUTH_TOKEN=... YC_FOLDER_ID=... npm run start path/to/example.ts
+YC_IAM_TOKEN=... YC_FOLDER_ID=... npm run start path/to/example.ts
 ```
 
 ## Services

--- a/examples/ai-translate.ts
+++ b/examples/ai-translate.ts
@@ -5,11 +5,11 @@ import { log } from './utils/logger';
 const { ai: { translate_translation_service: { TranslateRequest, TranslateRequest_Format: Format } } } = cloudApi;
 
 const TEXTS = ['NodeJS SDK examples', 'Powerful, but easy to use library'];
-const AUTH_TOKEN = getEnv('YC_OAUTH_TOKEN');
+const IAM_TOKEN = getEnv('YC_IAM_TOKEN');
 const FOLDER_ID = getEnv('YC_FOLDER_ID');
 
 (async () => {
-    const session = new Session({ oauthToken: AUTH_TOKEN });
+    const session = new Session({ iamToken: IAM_TOKEN });
     const client = session.client(serviceClients.TranslationServiceClient);
 
     const response = await client.translate(TranslateRequest.fromPartial({

--- a/examples/compute-instance-create.ts
+++ b/examples/compute-instance-create.ts
@@ -4,7 +4,7 @@ import {
 import { getEnv } from './utils/get-env';
 import { log } from './utils/logger';
 
-const AUTH_TOKEN = getEnv('YC_OAUTH_TOKEN');
+const IAM_TOKEN = getEnv('YC_IAM_TOKEN');
 const FOLDER_ID = getEnv('YC_FOLDER_ID');
 const TARGET_ZONE_ID = 'ru-central1-a';
 
@@ -30,7 +30,7 @@ const {
 } = cloudApi;
 
 (async () => {
-    const session = new Session({ oauthToken: AUTH_TOKEN });
+    const session = new Session({ iamToken: IAM_TOKEN });
     const imageClient = session.client(serviceClients.ComputeImageServiceClient);
     const instanceClient = session.client(serviceClients.InstanceServiceClient);
     const networkClient = session.client(serviceClients.NetworkServiceClient);

--- a/examples/functions.ts
+++ b/examples/functions.ts
@@ -3,11 +3,11 @@ import { getEnv } from './utils/get-env';
 import { log } from './utils/logger';
 
 const { serverless: { functions_function_service: { ListFunctionsRequest } } } = cloudApi;
-const AUTH_TOKEN = getEnv('YC_OAUTH_TOKEN');
+const IAM_TOKEN = getEnv('YC_IAM_TOKEN');
 const FOLDER_ID = getEnv('YC_FOLDER_ID');
 
 (async () => {
-    const session = new Session({ oauthToken: AUTH_TOKEN });
+    const session = new Session({ iamToken: IAM_TOKEN });
     const client = session.client(serviceClients.FunctionServiceClient);
 
     const response = await client.list(ListFunctionsRequest.fromPartial({ folderId: FOLDER_ID }));

--- a/examples/iot-data.ts
+++ b/examples/iot-data.ts
@@ -8,11 +8,11 @@ const {
         devices_registry_data_service: { PublishRegistryDataRequest },
     },
 } = cloudApi;
-const AUTH_TOKEN = getEnv('YC_OAUTH_TOKEN');
+const IAM_TOKEN = getEnv('YC_IAM_TOKEN');
 const FOLDER_ID = getEnv('YC_FOLDER_ID');
 
 (async () => {
-    const session = new Session({ oauthToken: AUTH_TOKEN });
+    const session = new Session({ iamToken: IAM_TOKEN });
     const registryClient = session.client(serviceClients.IotRegistryServiceClient);
     const dataClient = session.client(serviceClients.RegistryDataServiceClient);
 

--- a/examples/kms.ts
+++ b/examples/kms.ts
@@ -13,9 +13,9 @@ const {
 } = cloudApi;
 
 (async () => {
-    const authToken = getEnv('YC_OAUTH_TOKEN');
+    const iamToken = getEnv('YC_IAM_TOKEN');
     const folderId = getEnv('YC_FOLDER_ID');
-    const session = new Session({ oauthToken: authToken });
+    const session = new Session({ iamToken: iamToken });
     const keyClient = session.client(serviceClients.SymmetricKeyServiceClient);
     const cryptoClient = session.client(serviceClients.SymmetricCryptoServiceClient);
 

--- a/examples/resourcemanager-cloud-list.ts
+++ b/examples/resourcemanager-cloud-list.ts
@@ -3,10 +3,10 @@ import { getEnv } from './utils/get-env';
 import { log } from './utils/logger';
 
 const { resourcemanager: { cloud_service: { ListCloudsRequest } } } = cloudApi;
-const AUTH_TOKEN = getEnv('YC_OAUTH_TOKEN');
+const IAM_TOKEN = getEnv('YC_IAM_TOKEN');
 
 (async () => {
-    const session = new Session({ oauthToken: AUTH_TOKEN });
+    const session = new Session({ iamToken: IAM_TOKEN });
     const client = session.client(serviceClients.CloudServiceClient);
 
     const response = await client.list(ListCloudsRequest.fromPartial({ pageSize: 200 }));

--- a/examples/storage.ts
+++ b/examples/storage.ts
@@ -3,11 +3,11 @@ import { getEnv } from './utils/get-env';
 import { log } from './utils/logger';
 
 const { storage: { bucket_service: { ListBucketsRequest } } } = cloudApi;
-const AUTH_TOKEN = getEnv('YC_OAUTH_TOKEN');
+const IAM_TOKEN = getEnv('YC_IAM_TOKEN');
 const FOLDER_ID = getEnv('YC_FOLDER_ID');
 
 (async () => {
-    const session = new Session({ oauthToken: AUTH_TOKEN });
+    const session = new Session({ iamToken: IAM_TOKEN });
     const client = session.client(serviceClients.BucketServiceClient);
 
     const response = await client.list(ListBucketsRequest.fromPartial({ folderId: FOLDER_ID }));

--- a/examples/stream-stt/index.ts
+++ b/examples/stream-stt/index.ts
@@ -28,9 +28,9 @@ file.pipe(reader);
 reader.pipe(data);
 
 (async () => {
-    const authToken = getEnv('YC_OAUTH_TOKEN');
+    const iamToken = getEnv('YC_IAM_TOKEN');
     const folderId = getEnv('YC_FOLDER_ID');
-    const session = new Session({ oauthToken: authToken });
+    const session = new Session({ iamToken: iamToken });
     const client = session.client(serviceClients.SttServiceClient);
 
     async function* createRequest(): AsyncIterable<StreamingRecognitionRequest> {

--- a/src/session.ts
+++ b/src/session.ts
@@ -38,7 +38,7 @@ const newTokenCreator = (config: SessionConfig): () => Promise<string> => {
             const iamEndpoint = getServiceClientEndpoint(serviceClients.IamTokenServiceClient);
 
             console.warn(
-                'By the end of 2026 OAuthToken will be discontinued at Yandex Cloud. Please consider to use another credetials provider.'
+                'By the end of 2026 OAuthToken will be discontinued at Yandex Cloud. Please consider to use another credetials provider.',
             );
 
             return createIamToken(iamEndpoint, {

--- a/src/session.ts
+++ b/src/session.ts
@@ -36,7 +36,7 @@ const newTokenCreator = (config: SessionConfig): () => Promise<string> => {
     if (isOAuth(config)) {
         return () => {
             const iamEndpoint = getServiceClientEndpoint(serviceClients.IamTokenServiceClient);
-
+            console.warn("The OAuthToken credential provider is deprecated at Yandex Cloud. By the end of 2026 will be fully discontinued. Please consider to use another credetials provider.");
             return createIamToken(iamEndpoint, {
                 yandexPassportOauthToken: config.oauthToken,
             });

--- a/src/session.ts
+++ b/src/session.ts
@@ -36,7 +36,11 @@ const newTokenCreator = (config: SessionConfig): () => Promise<string> => {
     if (isOAuth(config)) {
         return () => {
             const iamEndpoint = getServiceClientEndpoint(serviceClients.IamTokenServiceClient);
-            console.warn("The OAuthToken credential provider is deprecated at Yandex Cloud. By the end of 2026 will be fully discontinued. Please consider to use another credetials provider.");
+
+            console.warn(
+                'By the end of 2026 OAuthToken will be discontinued at Yandex Cloud. Please consider to use another credetials provider.'
+            );
+
             return createIamToken(iamEndpoint, {
                 yandexPassportOauthToken: config.oauthToken,
             });

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,10 @@ export interface GenericCredentialsConfig {
     headers?: Record<string, string>;
 }
 
+/**
+ * @deprecated By the end of 2026, the use of oauth tokens in the Yandex cloud will be discontinued.
+ * Please consider to use another credentials provider.
+ */
 export interface OAuthCredentialsConfig extends GenericCredentialsConfig {
     oauthToken: string;
 }


### PR DESCRIPTION
By the end of 2026, it is planned to discontinue support for OAuthToken in Yandex Cloud. In this regard, it is necessary to release a new version of the public sdk, in which mark the corresponding CredentialsProvider as deprecated.